### PR TITLE
Refactor wavefunction

### DIFF
--- a/docs/source/reference/wavefunction.scalar.rst
+++ b/docs/source/reference/wavefunction.scalar.rst
@@ -11,7 +11,7 @@ Constructing the Wavefunction object is done through the constructor
 .. autosummary::
     :toctree: generated/
 
-    Wavefunction
+    ScalarWavefunction
 
 Here, the parameter `grid` is a :class:`Grid` object defined prior to instantiating the Wavefunction class.
 
@@ -25,9 +25,9 @@ Below are the methods associated with the initial state.
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.set_wavefunction
-   Wavefunction.add_noise
-   Wavefunction.apply_phase
+   ScalarWavefunction.set_wavefunction
+   ScalarWavefunction.add_noise
+   ScalarWavefunction.apply_phase
 
 The `set_wavefunction` method is used to set the initial state to whatever we desire.
 The `add_noise` method adds noise to each grid point of the wavefunction where the noise is drawn from a uniform
@@ -42,10 +42,10 @@ The methods below fall under the miscellaneous category and are self-explanatory
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.fft
-   Wavefunction.ifft
-   Wavefunction.density
+   ScalarWavefunction.fft
+   ScalarWavefunction.ifft
+   ScalarWavefunction.density
 
 Attributes
 ----------
-See :class:`Wavefunction` for list of class attributes (variables).
+See :class:`ScalarWavefunction` for list of class attributes (variables).

--- a/docs/source/reference/wavefunction.spinhalf.rst
+++ b/docs/source/reference/wavefunction.spinhalf.rst
@@ -11,7 +11,7 @@ Constructing the Wavefunction object is done through the constructor
 .. autosummary::
     :toctree: generated/
 
-    Wavefunction
+    SpinHalfWavefunction
 
 Here, the parameter `grid` is a :class:`Grid` object defined prior to instantiating the Wavefunction class.
 
@@ -25,16 +25,16 @@ Below are the methods associated with the initial state.
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.set_wavefunction_components
-   Wavefunction.add_noise_to_components
-   Wavefunction.apply_phase
+   SpinHalfWavefunction.set_wavefunction
+   SpinHalfWavefunction.add_noise
+   SpinHalfWavefunction.apply_phase
 
-The `set_wavefunction_components` method is used to set the initial state of the two-component system.
+The `set_wavefunction` method is used to set the initial state of the two-component system.
 
-The `add_noise_to_components` method adds noise to each grid point of the wavefunction for the specified components.
+The `add_noise` method adds noise to each grid point of the wavefunction for the specified components.
 The noise is drawn from a uniform distribution with the mean and standard deviation specified in the function signature.
 Finally, `apply_phase` applies a user-defined phase to the specified wavefunction components as
-:math:`\psi_m\rightarrow\psi_m e^{i\phi}` for phase :math:`\phi` and component :math:`m \in \{+, 0, -\}`.
+:math:`\psi_m\rightarrow\psi_m e^{i\phi}` for phase :math:`\phi` and component :math:`m \in \{1, 2\}`.
 
 Other methods
 -------------
@@ -43,9 +43,10 @@ The methods below fall under the miscellaneous category and are self-explanatory
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.fft
-   Wavefunction.ifft
+   SpinHalfWavefunction.fft
+   SpinHalfWavefunction.ifft
+   SpinHalfWavefunction.density
 
 Attributes
 ----------
-See :class:`Wavefunction` for list of class attributes (variables).
+See :class:`SpinHalfWavefunction` for list of class attributes (variables).

--- a/docs/source/reference/wavefunction.spinone.rst
+++ b/docs/source/reference/wavefunction.spinone.rst
@@ -11,7 +11,7 @@ Constructing the Wavefunction object is done through the constructor
 .. autosummary::
     :toctree: generated/
 
-    Wavefunction
+    SpinOneWavefunction
 
 Here, the parameter `grid` is a :class:`Grid` object defined prior to instantiating the Wavefunction class.
 
@@ -25,10 +25,10 @@ Below are the methods associated with the initial state.
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.set_ground_state
-   Wavefunction.set_custom_components
-   Wavefunction.add_noise_to_components
-   Wavefunction.apply_phase
+   SpinOneWavefunction.set_ground_state
+   SpinOneWavefunction.set_wavefunction
+   SpinOneWavefunction.add_noise
+   SpinOneWavefunction.apply_phase
 
 The `set_ground_state` method is used to set the initial state to a specified ground state of the spin-1 system.
 It is typically the way we start shaping the condensate.
@@ -66,9 +66,9 @@ The broken-axisymmetry wavefunction components are
     \psi_0 = \sqrt{\frac{(q^2-p^2)(-p^2-q^2+2c_2nq)}{4c_2nq^3}}.
 
 
-If more flexibility is required, the `set_custom_components` method allows us to set specific components to specified
+If more flexibility is required, the `set_wavefunction` method allows us to set specific components to specified
 arrays.
-The `add_noise_to_components` method adds noise to each grid point of the wavefunction for the specified components.
+The `add_noise` method adds noise to each grid point of the wavefunction for the specified components.
 The noise is drawn from a uniform distribution with the mean and standard deviation specified in the function signature.
 Finally, `apply_phase` applies a user-defined phase to the specified wavefunction components as
 :math:`\psi_m\rightarrow\psi_m e^{i\phi}` for phase :math:`\phi` and component :math:`m \in \{+, 0, -\}`.
@@ -80,9 +80,10 @@ The methods below fall under the miscellaneous category and are self-explanatory
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.fft
-   Wavefunction.ifft
+   SpinOneWavefunction.fft
+   SpinOneWavefunction.ifft
+   SpinOneWavefunction.density
 
 Attributes
 ----------
-See :class:`Wavefunction` for list of class attributes (variables).
+See :class:`SpinOneWavefunction` for list of class attributes (variables).

--- a/docs/source/reference/wavefunction.spintwo.rst
+++ b/docs/source/reference/wavefunction.spintwo.rst
@@ -11,7 +11,7 @@ Constructing the Wavefunction object is done through the constructor
 .. autosummary::
     :toctree: generated/
 
-    Wavefunction
+    SpinTwoWavefunction
 
 Here, the parameter `grid` is a :class:`Grid` object defined prior to instantiating the Wavefunction class.
 
@@ -25,10 +25,10 @@ Below are the methods associated with the initial state.
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.set_ground_state
-   Wavefunction.set_custom_components
-   Wavefunction.add_noise_to_components
-   Wavefunction.apply_phase
+   SpinTwoWavefunction.set_ground_state
+   SpinTwoWavefunction.set_wavefunction
+   SpinTwoWavefunction.add_noise
+   SpinTwoWavefunction.apply_phase
 
 The `set_ground_state` method is used to set the initial state to a specified ground state of the spin-2 system.
 It is typically the way we start shaping the condensate.
@@ -69,9 +69,9 @@ The supported ground states are listed below
       - :math:`\psi=(\sqrt{(1 + f_z) / 3}, 0, 0, \sqrt{(2 - f_z) / 3}, 0)^T`
       - Cyclic ground state where :math:`f_z=p+q/c_2n`.
 
-If more flexibility is required, the `set_custom_components` method allows us to set specific components to specified
+If more flexibility is required, the `set_wavefunction` method allows us to set specific components to specified
 arrays.
-The `add_noise_to_components` method adds noise to each grid point of the wavefunction for the specified components.
+The `add_noise` method adds noise to each grid point of the wavefunction for the specified components.
 The noise is drawn from a uniform distribution with the mean and standard deviation specified in the function signature.
 Finally, `apply_phase` applies a user-defined phase to the specified wavefunction components as
 :math:`\psi_m\rightarrow\psi_m e^{i\phi}` for phase :math:`\phi` and component :math:`m \in \{2, 1, 0 , -1, -2\}`.
@@ -83,9 +83,10 @@ The methods below fall under the miscellaneous category and are self-explanatory
 .. autosummary::
    :toctree: generated/
 
-   Wavefunction.fft
-   Wavefunction.ifft
+   SpinTwoWavefunction.fft
+   SpinTwoWavefunction.ifft
+   SpinTwoWavefunction.density
 
 Attributes
 ----------
-See :class:`Wavefunction` for list of class attributes (variables).
+See :class:`SpinTwoWavefunction` for list of class attributes (variables).

--- a/docs/source/user/starter_guide.rst
+++ b/docs/source/user/starter_guide.rst
@@ -83,7 +83,7 @@ dimension and their respective grid spacings, then generate a Grid object::
 
 The above code generates a 3D grid with 64 points and a grid spacing of 0.5 in
 each dimension.
-To create grids of different dimensionality you only need change the grid_points
+To create grids of different dimensionality you only need to change the grid_points
 and grid_spacings to match the desired dimensionality.
 For example, to create a 2D grid we would instead have
 :code:`grid_points = (64, 64)` and :code:`grid_spacings = (0.5, 0.5)`.
@@ -129,12 +129,30 @@ Setting up the wavefunction
 Now that we have a grid class, we can use this to set up our wavefunction.
 Setting up the initial wavefunction class is easy, we just need to pass in the
 grid we have constructed.
+The name of the wavefunction class in the respective system is given in the
+table below:
+
+.. list-table::
+    :widths: 25 25
+    :header-rows: 1
+
+    * - System type
+      - Wavefunction Class
+    * - Scalar BEC
+      - :code:`ScalarWavefunction(grid)`
+    * - Two-component BEC
+      - :code:`SpinHalfWavefunction(grid)`
+    * - Spin-1 BEC
+      - :code:`SpinOneWavefunction(grid)`
+    * - Spin-2 BEC
+      - :code:`SpinTwoWavefunction(grid)`
+
 Then we can use the class methods to manipulate the wavefunction into the
 desired initial state::
 
-    wavefunction = gpe.Wavefunction(grid)
+    wavefunction = gpe.SpinOneWavefunction(grid)
     wavefunction.set_ground_state("polar")
-    wavefunction.add_noise_to_components(components="outer", mean=0., std=1e-2)
+    wavefunction.add_noise(components="outer", mean=0., std=1e-2)
 
 This first creates a wavefunction in a polar state :math:`\psi=(0,1,0)^T` then
 subsequently adds numerical noise drawn from a normal distribution with mean

--- a/examples/scalar/2d_SQV_imprinting.py
+++ b/examples/scalar/2d_SQV_imprinting.py
@@ -10,7 +10,7 @@ grid_spacings = (0.5, 0.5)
 grid = gpe.Grid(points, grid_spacings)
 
 # Set up initial wavefunction with uniform density
-psi = gpe.Wavefunction(grid)
+psi = gpe.ScalarWavefunction(grid)
 psi.set_wavefunction(cp.ones(grid.shape, dtype="complex128"))
 psi.add_noise(mean=0.0, std_dev=1e-2)  # Add noise to wavefunction
 

--- a/examples/spinone/2d_SQV_imprinting.py
+++ b/examples/spinone/2d_SQV_imprinting.py
@@ -24,9 +24,9 @@ params = {
 }
 
 # Generate wavefunction object, set initial state and add noise
-psi = gpe.Wavefunction(grid)
+psi = gpe.SpinOneWavefunction(grid)
 psi.set_ground_state("polar", params)
-psi.add_noise_to_components("outer", 0.0, 1e-2)
+psi.add_noise("outer", 0.0, 1e-2)
 
 phase = cp.asarray(
     vort.vortex_phase_profile(grid, 100, 1)

--- a/pygpe/scalar/data_manager.py
+++ b/pygpe/scalar/data_manager.py
@@ -2,7 +2,7 @@ import h5py
 import cupy as cp
 from pygpe.shared.grid import Grid
 from pygpe.shared import data_manager_paths as dmp
-from pygpe.scalar.wavefunction import Wavefunction
+from pygpe.scalar.wavefunction import ScalarWavefunction
 
 
 class DataManager:
@@ -28,7 +28,7 @@ class DataManager:
         h5py.File(f"{self.data_path}/{self.filename}", "w")
 
     def save_initial_parameters(
-        self, grid: Grid, wfn: Wavefunction, parameters: dict
+        self, grid: Grid, wfn: ScalarWavefunction, parameters: dict
     ) -> None:
         """Saves the initial grid, wavefunction and parameters to a HDF5 file.
 
@@ -67,7 +67,7 @@ class DataManager:
                 file.create_dataset(dmp.GRID_DY, data=grid.grid_spacing_y)
                 file.create_dataset(dmp.GRID_DZ, data=grid.grid_spacing_z)
 
-    def _save_initial_wfn(self, wfn: Wavefunction) -> None:
+    def _save_initial_wfn(self, wfn: ScalarWavefunction) -> None:
         """Saves initial wavefunction to dataset."""
         with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
             if wfn.grid.ndim == 1:
@@ -93,7 +93,7 @@ class DataManager:
                     f"{dmp.PARAMETERS}/{key}", data=parameters[key]
                 )
 
-    def save_wavefunction(self, wfn: Wavefunction) -> None:
+    def save_wavefunction(self, wfn: ScalarWavefunction) -> None:
         """Saves the current wavefunction data to the dataset.
 
         :param wfn: The wavefunction of the system.

--- a/pygpe/scalar/evolution.py
+++ b/pygpe/scalar/evolution.py
@@ -1,8 +1,8 @@
 import cupy as cp
-from pygpe.scalar.wavefunction import Wavefunction
+from pygpe.scalar.wavefunction import ScalarWavefunction
 
 
-def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
+def step_wavefunction(wfn: ScalarWavefunction, params: dict) -> None:
     """Propagates the wavefunction forward one time step.
 
     :param wfn: The wavefunction of the system.
@@ -19,7 +19,7 @@ def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
         _renormalise_wavefunction(wfn)
 
 
-def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
+def _kinetic_step(wfn: ScalarWavefunction, pm: dict) -> None:
     """Computes the kinetic energy subsystem for half a time step.
 
     :param wfn: The wavefunction of the system.
@@ -30,7 +30,7 @@ def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _potential_step(wfn: Wavefunction, pm: dict) -> None:
+def _potential_step(wfn: ScalarWavefunction, pm: dict) -> None:
     """Computes the potential subsystem for a full time step.
 
     :param wfn: The wavefunction of the system.
@@ -41,7 +41,7 @@ def _potential_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _renormalise_wavefunction(wfn: Wavefunction) -> None:
+def _renormalise_wavefunction(wfn: ScalarWavefunction) -> None:
     """Re-normalises the wavefunction to the correct atom number.
 
     :param wfn: The wavefunction of the system.
@@ -53,7 +53,7 @@ def _renormalise_wavefunction(wfn: Wavefunction) -> None:
     wfn.fft()
 
 
-def _calculate_atom_num(wfn: Wavefunction) -> float:
+def _calculate_atom_num(wfn: ScalarWavefunction) -> float:
     """Calculates the current atom number of the wavefunction.
 
     :param wfn: The wavefunction of the system.

--- a/pygpe/scalar/wavefunction.py
+++ b/pygpe/scalar/wavefunction.py
@@ -1,9 +1,9 @@
 from pygpe.shared.grid import Grid
-from pygpe.shared.wavefunction import Wavefunction
+from pygpe.shared.wavefunction import _Wavefunction
 import cupy as cp
 
 
-class ScalarWavefunction(Wavefunction):
+class ScalarWavefunction(_Wavefunction):
     """Represents the scalar BEC wavefunction.
     This class contains the wavefunction array, in addition to various useful
     functions for manipulating and using the wavefunction.

--- a/pygpe/scalar/wavefunction.py
+++ b/pygpe/scalar/wavefunction.py
@@ -1,8 +1,9 @@
 from pygpe.shared.grid import Grid
+from pygpe.shared.wavefunction import Wavefunction
 import cupy as cp
 
 
-class Wavefunction:
+class ScalarWavefunction(Wavefunction):
     """Represents the scalar BEC wavefunction.
     This class contains the wavefunction array, in addition to various useful
     functions for manipulating and using the wavefunction.
@@ -18,7 +19,7 @@ class Wavefunction:
 
     def __init__(self, grid: Grid):
         """Constructs the wavefunction object."""
-        self.grid = grid
+        super().__init__(grid)
 
         self.component = cp.empty(grid.shape, dtype="complex128")
         self.fourier_component = cp.empty(
@@ -44,18 +45,8 @@ class Wavefunction:
         :param std_dev: The standard deviation of the normal distribution.
         :type std_dev: float
         """
-        self.component += self._generate_complex_normal_dist(mean, std_dev)
+        self.component += super()._generate_complex_normal_dist(mean, std_dev)
         self._update_atom_number()
-
-    def _generate_complex_normal_dist(
-        self, mean: float, std_dev: float
-    ) -> cp.ndarray:
-        """Returns a ndarray of complex values containing results from
-        a normal distribution.
-        """
-        return cp.random.normal(
-            mean, std_dev, size=self.grid.shape
-        ) + 1j * cp.random.normal(mean, std_dev, size=self.grid.shape)
 
     def apply_phase(self, phase: cp.ndarray) -> None:
         """Applies a phase to the wavefunction.

--- a/pygpe/shared/wavefunction.py
+++ b/pygpe/shared/wavefunction.py
@@ -1,0 +1,75 @@
+from abc import ABC, abstractmethod
+from grid import Grid
+import cupy as cp
+
+
+class Wavefunction(ABC):
+    def __init__(self, grid: Grid) -> None:
+        """The default constructor for the abstract `Wavefunction` class, to be
+        inherited by subclasses of `Wavefunction`.
+
+        :param grid: _description_
+        :type grid: Grid
+        """
+        self.grid = grid
+
+    @abstractmethod
+    def set_wavefunction(self) -> None:
+        """Sets the components of the wavefunction to the specified
+        array(s).
+        """
+        pass
+
+    @abstractmethod
+    def add_noise(self, *args, mean: float, std_dev: float) -> None:
+        """Adds noise to the specified component(s), drawn from a normal
+        distribution.
+
+        :param mean: Mean of the normal distribution.
+        :type mean: float
+        :param std_dev: Standard deviation of the normal distribution.
+        :type std_dev: float
+        """
+        pass
+
+    def _generate_complex_normal_dist(
+        self, mean: float, std_dev: float
+    ) -> cp.ndarray:
+        """Returns a `cp.ndarray` of complex values containing results from
+        a normal distribution.
+        """
+        return cp.random.normal(
+            mean, std_dev, size=self.grid.shape
+        ) + 1j * cp.random.normal(mean, std_dev, size=self.grid.shape)
+
+    @abstractmethod
+    def apply_phase(self, phase: cp.ndarray, **kwargs) -> None:
+        """Applies a phase to the specified component(s).
+
+        :param phase: Array of the condensate phase.
+        :type phase: cp.ndarray
+        """
+        pass
+
+    @abstractmethod
+    def fft(self) -> None:
+        """Computes the forward Fourier transform on all wavefunction
+        components.
+        """
+        pass
+
+    @abstractmethod
+    def ifft(self) -> None:
+        """Computes the backward Fourier transform on all k-space wavefunction
+        components.
+        """
+        pass
+
+    @abstractmethod
+    def density(self) -> cp.ndarray:
+        """Computes the total density of the condensate.
+
+        :return: Total density of the condensate.
+        :rtype: cp.ndarray
+        """
+        pass

--- a/pygpe/shared/wavefunction.py
+++ b/pygpe/shared/wavefunction.py
@@ -3,7 +3,7 @@ from pygpe.shared.grid import Grid
 import cupy as cp
 
 
-class Wavefunction(ABC):
+class _Wavefunction(ABC):
     def __init__(self, grid: Grid) -> None:
         """The default constructor for the abstract `Wavefunction` class, to be
         inherited by subclasses of `Wavefunction`.

--- a/pygpe/shared/wavefunction.py
+++ b/pygpe/shared/wavefunction.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from grid import Grid
+from pygpe.shared.grid import Grid
 import cupy as cp
 
 

--- a/pygpe/spinhalf/data_manager.py
+++ b/pygpe/spinhalf/data_manager.py
@@ -2,7 +2,7 @@ import h5py
 import cupy as cp
 from pygpe.shared.grid import Grid
 from pygpe.shared import data_manager_paths as dmp
-from pygpe.spinhalf.wavefunction import Wavefunction
+from pygpe.spinhalf.wavefunction import SpinHalfWavefunction
 
 
 class DataManager:
@@ -27,7 +27,7 @@ class DataManager:
         h5py.File(f"{self.data_path}/{self.filename}", "w")
 
     def save_initial_parameters(
-        self, grid: Grid, wfn: Wavefunction, parameters: dict
+        self, grid: Grid, wfn: SpinHalfWavefunction, parameters: dict
     ) -> None:
         """Saves the initial grid, wavefunction and parameters to a HDF5 file.
 
@@ -68,7 +68,7 @@ class DataManager:
                 file.create_dataset(dmp.GRID_DY, data=grid.grid_spacing_y)
                 file.create_dataset(dmp.GRID_DZ, data=grid.grid_spacing_z)
 
-    def _save_initial_wfn(self, wfn: Wavefunction) -> None:
+    def _save_initial_wfn(self, wfn: SpinHalfWavefunction) -> None:
         """Creates new datasets in file for the wavefunction and saves
         initial values.
         """
@@ -108,7 +108,7 @@ class DataManager:
             for key in parameters:
                 file.create_dataset(f"parameters/{key}", data=parameters[key])
 
-    def save_wavefunction(self, wfn: Wavefunction) -> None:
+    def save_wavefunction(self, wfn: SpinHalfWavefunction) -> None:
         """Saves the current wavefunction data to the dataset.
 
         :param wfn: The wavefunction of the system.

--- a/pygpe/spinhalf/evolution.py
+++ b/pygpe/spinhalf/evolution.py
@@ -1,8 +1,8 @@
 import cupy as cp
-from pygpe.spinhalf.wavefunction import Wavefunction
+from pygpe.spinhalf.wavefunction import SpinHalfWavefunction
 
 
-def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
+def step_wavefunction(wfn: SpinHalfWavefunction, params: dict) -> None:
     """Propagates the wavefunction forward one time step.
 
     :param wfn: The wavefunction of the system.
@@ -19,7 +19,7 @@ def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
         _renormalise_wavefunction(wfn)
 
 
-def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
+def _kinetic_step(wfn: SpinHalfWavefunction, pm: dict) -> None:
     """Computes the kinetic energy subsystem for half a time step.
 
     :param wfn: The wavefunction of the system.
@@ -33,7 +33,7 @@ def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _potential_step(wfn: Wavefunction, pm: dict) -> None:
+def _potential_step(wfn: SpinHalfWavefunction, pm: dict) -> None:
     """Computes the potential subsystem for a full time step.
 
     :param wfn: The wavefunction of the system.
@@ -62,7 +62,7 @@ def _potential_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _renormalise_wavefunction(wfn: Wavefunction) -> None:
+def _renormalise_wavefunction(wfn: SpinHalfWavefunction) -> None:
     """Re-normalises the wavefunction to the correct atom number.
 
     :param wfn: The wavefunction of the system.
@@ -78,7 +78,7 @@ def _renormalise_wavefunction(wfn: Wavefunction) -> None:
     wfn.fft()
 
 
-def _calculate_atom_num(wfn: Wavefunction) -> tuple[int, int]:
+def _calculate_atom_num(wfn: SpinHalfWavefunction) -> tuple[int, int]:
     """Calculates the atom number of each wavefunction component.
 
     :param wfn: The wavefunction of the system.

--- a/pygpe/spinhalf/wavefunction.py
+++ b/pygpe/spinhalf/wavefunction.py
@@ -1,9 +1,9 @@
 from pygpe.shared.grid import Grid
-from pygpe.shared.wavefunction import Wavefunction
+from pygpe.shared.wavefunction import _Wavefunction
 import cupy as cp
 
 
-class SpinHalfWavefunction(Wavefunction):
+class SpinHalfWavefunction(_Wavefunction):
     def __init__(self, grid: Grid):
         """Constructs the wavefunction object."""
         super().__init__(grid)

--- a/pygpe/spinhalf/wavefunction.py
+++ b/pygpe/spinhalf/wavefunction.py
@@ -1,11 +1,12 @@
 from pygpe.shared.grid import Grid
+from pygpe.shared.wavefunction import Wavefunction
 import cupy as cp
 
 
-class Wavefunction:
+class SpinHalfWavefunction(Wavefunction):
     def __init__(self, grid: Grid):
         """Constructs the wavefunction object."""
-        self.grid = grid
+        super().__init__(grid)
 
         self.plus_component = cp.empty(grid.shape, dtype="complex128")
         self.minus_component = cp.empty(grid.shape, dtype="complex128")
@@ -15,7 +16,7 @@ class Wavefunction:
         self.atom_num_plus = 0
         self.atom_num_minus = 0
 
-    def set_wavefunction_components(
+    def set_wavefunction(
         self, plus_component: cp.ndarray, minus_component: cp.ndarray
     ) -> None:
         """Set the wavefunction components to the specified arrays.
@@ -38,9 +39,7 @@ class Wavefunction:
             cp.abs(self.minus_component) ** 2
         )
 
-    def add_noise_to_components(
-        self, components: str, mean: float, std_dev: float
-    ) -> None:
+    def add_noise(self, components: str, mean: float, std_dev: float) -> None:
         """Adds noise to the specified wavefunction components
         using a normal distribution.
 
@@ -51,34 +50,24 @@ class Wavefunction:
         """
         match components.lower():
             case "plus":
-                self.plus_component += self._generate_complex_normal_dist(
+                self.plus_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "minus":
-                self.minus_component += self._generate_complex_normal_dist(
+                self.minus_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "all":
-                self.plus_component += self._generate_complex_normal_dist(
+                self.plus_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
-                self.minus_component += self._generate_complex_normal_dist(
+                self.minus_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case _:
                 raise ValueError(
                     f"{components} is not a supported configuration"
                 )
-
-    def _generate_complex_normal_dist(
-        self, mean: float, std_dev: float
-    ) -> cp.ndarray:
-        """Returns a ndarray of complex values containing results from
-        a normal distribution.
-        """
-        return cp.random.normal(
-            mean, std_dev, size=self.grid.shape
-        ) + 1j * cp.random.normal(mean, std_dev, size=self.grid.shape)
 
     def apply_phase(self, phase: cp.ndarray, components: str = "all") -> None:
         """Applies a given phase to the specified condensate components.

--- a/pygpe/spinone/data_manager.py
+++ b/pygpe/spinone/data_manager.py
@@ -2,7 +2,7 @@ import h5py
 import cupy as cp
 from pygpe.shared.grid import Grid
 from pygpe.shared import data_manager_paths as dmp
-from pygpe.spinone.wavefunction import Wavefunction
+from pygpe.spinone.wavefunction import SpinOneWavefunction
 
 
 class DataManager:
@@ -27,7 +27,7 @@ class DataManager:
         h5py.File(f"{self.data_path}/{self.filename}", "w")
 
     def save_initial_parameters(
-        self, grid: Grid, wfn: Wavefunction, parameters: dict
+        self, grid: Grid, wfn: SpinOneWavefunction, parameters: dict
     ) -> None:
         """Saves the initial grid, wavefunction and parameters to a HDF5 file.
 
@@ -68,7 +68,7 @@ class DataManager:
                 file.create_dataset(dmp.GRID_DY, data=grid.grid_spacing_y)
                 file.create_dataset(dmp.GRID_DZ, data=grid.grid_spacing_z)
 
-    def _save_initial_wfn(self, wfn: Wavefunction) -> None:
+    def _save_initial_wfn(self, wfn: SpinOneWavefunction) -> None:
         """Creates new datasets in file for the wavefunction and saves
         initial values.
         """
@@ -120,7 +120,7 @@ class DataManager:
             for key in parameters:
                 file.create_dataset(f"parameters/{key}", data=parameters[key])
 
-    def save_wavefunction(self, wfn: Wavefunction) -> None:
+    def save_wavefunction(self, wfn: SpinOneWavefunction) -> None:
         """Saves the current wavefunction data to the dataset.
 
         :param wfn: The wavefunction of the system.

--- a/pygpe/spinone/evolution.py
+++ b/pygpe/spinone/evolution.py
@@ -1,8 +1,8 @@
 import cupy as cp
-from pygpe.spinone.wavefunction import Wavefunction
+from pygpe.spinone.wavefunction import SpinOneWavefunction
 
 
-def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
+def step_wavefunction(wfn: SpinOneWavefunction, params: dict) -> None:
     """Propagates the wavefunction forward one time step.
 
     :param wfn: The wavefunction of the system.
@@ -19,7 +19,7 @@ def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
         _renormalise_wavefunction(wfn)
 
 
-def _kinetic_zeeman_step(wfn: Wavefunction, pm: dict) -> None:
+def _kinetic_zeeman_step(wfn: SpinOneWavefunction, pm: dict) -> None:
     """Computes the kinetic-zeeman subsystem for half a time step.
 
     :param wfn: The wavefunction of the system.
@@ -36,7 +36,7 @@ def _kinetic_zeeman_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _interaction_step(wfn: Wavefunction, pm: dict) -> None:
+def _interaction_step(wfn: SpinOneWavefunction, pm: dict) -> None:
     """Computes the interaction subsystem for a full time step.
 
     :param wfn: The wavefunction of the system.
@@ -74,7 +74,9 @@ def _interaction_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _calculate_spins(wfn: Wavefunction) -> tuple[cp.ndarray, cp.ndarray]:
+def _calculate_spins(
+    wfn: SpinOneWavefunction,
+) -> tuple[cp.ndarray, cp.ndarray]:
     """Calculates the perpendicular and longitudinal spins.
 
     :param wfn: The wavefunction of the system.
@@ -89,7 +91,7 @@ def _calculate_spins(wfn: Wavefunction) -> tuple[cp.ndarray, cp.ndarray]:
     return spin_perp, spin_z
 
 
-def _calculate_density(wfn: Wavefunction) -> cp.ndarray:
+def _calculate_density(wfn: SpinOneWavefunction) -> cp.ndarray:
     """Calculates the total condensate density.
 
     :param wfn: The wavefunction of the system.
@@ -102,7 +104,7 @@ def _calculate_density(wfn: Wavefunction) -> cp.ndarray:
     )
 
 
-def _renormalise_wavefunction(wfn: Wavefunction) -> None:
+def _renormalise_wavefunction(wfn: SpinOneWavefunction) -> None:
     """Re-normalises the wavefunction to the correct atom number.
 
     :param wfn: The wavefunction of the system.
@@ -124,7 +126,7 @@ def _renormalise_wavefunction(wfn: Wavefunction) -> None:
     wfn.fft()
 
 
-def _calculate_atom_num(wfn: Wavefunction) -> tuple[int, int, int]:
+def _calculate_atom_num(wfn: SpinOneWavefunction) -> tuple[int, int, int]:
     """Calculates the atom number of each wavefunction component.
 
     :param wfn: The wavefunction of the system.

--- a/pygpe/spinone/wavefunction.py
+++ b/pygpe/spinone/wavefunction.py
@@ -1,9 +1,9 @@
 from pygpe.shared.grid import Grid
-from pygpe.shared.wavefunction import Wavefunction
+from pygpe.shared.wavefunction import _Wavefunction
 import cupy as cp
 
 
-class SpinOneWavefunction(Wavefunction):
+class SpinOneWavefunction(_Wavefunction):
     """Represents the spin-1 BEC wavefunction.
     This class contains the wavefunction arrays, in addition to various useful
     functions for manipulating and using the wavefunction.

--- a/pygpe/spinone/wavefunction.py
+++ b/pygpe/spinone/wavefunction.py
@@ -137,7 +137,7 @@ class SpinOneWavefunction(Wavefunction):
 
         :param phase: The phase to be applied.
         :param components: "all", "plus", "zero", "minus" or a list of strings
-        specifying the required components.
+            specifying the required components.
         """
         match components:
             case [*_]:

--- a/pygpe/spintwo/data_manager.py
+++ b/pygpe/spintwo/data_manager.py
@@ -2,7 +2,7 @@ import h5py
 import cupy as cp
 from pygpe.shared.grid import Grid
 from pygpe.shared import data_manager_paths as dmp
-from pygpe.spintwo.wavefunction import Wavefunction
+from pygpe.spintwo.wavefunction import SpinTwoWavefunction
 
 
 class DataManager:
@@ -27,7 +27,7 @@ class DataManager:
         h5py.File(f"{self.data_path}/{self.filename}", "w")
 
     def save_initial_parameters(
-        self, grid: Grid, wfn: Wavefunction, parameters: dict
+        self, grid: Grid, wfn: SpinTwoWavefunction, parameters: dict
     ) -> None:
         """Saves the initial grid, wavefunction and parameters to a HDF5 file.
 
@@ -68,7 +68,7 @@ class DataManager:
                 file.create_dataset(dmp.GRID_DY, data=grid.grid_spacing_y)
                 file.create_dataset(dmp.GRID_DZ, data=grid.grid_spacing_z)
 
-    def _save_initial_wfn(self, wfn: Wavefunction) -> None:
+    def _save_initial_wfn(self, wfn: SpinTwoWavefunction) -> None:
         """Creates new datasets in file for the wavefunction."""
         with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
             if wfn.grid.ndim == 1:
@@ -142,7 +142,7 @@ class DataManager:
             for key in parameters:
                 file.create_dataset(f"parameters/{key}", data=parameters[key])
 
-    def save_wavefunction(self, wfn: Wavefunction) -> None:
+    def save_wavefunction(self, wfn: SpinTwoWavefunction) -> None:
         """Saves the current wavefunction data to the dataset.
 
         :param wfn: The wavefunction of the system.

--- a/pygpe/spintwo/evolution.py
+++ b/pygpe/spintwo/evolution.py
@@ -1,8 +1,8 @@
 import cupy as cp
-from pygpe.spintwo.wavefunction import Wavefunction
+from pygpe.spintwo.wavefunction import SpinTwoWavefunction
 
 
-def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
+def step_wavefunction(wfn: SpinTwoWavefunction, params: dict) -> None:
     """Propagates the wavefunction forward one time step.
 
     :param wfn: The wavefunction of the system.
@@ -19,7 +19,7 @@ def step_wavefunction(wfn: Wavefunction, params: dict) -> None:
         _renormalise_wavefunction(wfn)
 
 
-def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
+def _kinetic_step(wfn: SpinTwoWavefunction, pm: dict) -> None:
     """Computes the kinetic energy subsystem for half a time step.
 
     :param wfn: The wavefunction of the system.
@@ -42,7 +42,7 @@ def _kinetic_step(wfn: Wavefunction, pm: dict) -> None:
     )
 
 
-def _interaction_step(wfn: Wavefunction, pm: dict) -> None:
+def _interaction_step(wfn: SpinTwoWavefunction, pm: dict) -> None:
     # Calculate density and singlets
     n = _density(wfn)
     a20 = _singlet_duo(wfn)
@@ -95,7 +95,7 @@ def _interaction_step(wfn: Wavefunction, pm: dict) -> None:
     wfn.minus2_component = temp_wfn[4]
 
 
-def _density(wfn: Wavefunction) -> cp.ndarray:
+def _density(wfn: SpinTwoWavefunction) -> cp.ndarray:
     return (
         abs(wfn.plus2_component) ** 2
         + abs(wfn.plus1_component) ** 2
@@ -105,7 +105,7 @@ def _density(wfn: Wavefunction) -> cp.ndarray:
     )
 
 
-def _singlet_duo(wfn: Wavefunction) -> cp.ndarray:
+def _singlet_duo(wfn: SpinTwoWavefunction) -> cp.ndarray:
     return (
         1
         / cp.sqrt(5)
@@ -118,7 +118,7 @@ def _singlet_duo(wfn: Wavefunction) -> cp.ndarray:
 
 
 def _evolve_spin_singlet(
-    wfn: Wavefunction, dens: cp.ndarray, singlet: cp.ndarray, pm: dict
+    wfn: SpinTwoWavefunction, dens: cp.ndarray, singlet: cp.ndarray, pm: dict
 ) -> list[cp.ndarray]:
     s = cp.nan_to_num(cp.sqrt(dens**2 - abs(singlet) ** 2))
     cos_term = cp.cos(pm["c4"] * s * pm["dt"])
@@ -210,7 +210,7 @@ def _calc_qpsi(fz, fp, wfn):
     return qpsi
 
 
-def _renormalise_wavefunction(wfn: Wavefunction) -> None:
+def _renormalise_wavefunction(wfn: SpinTwoWavefunction) -> None:
     """Re-normalises the wavefunction to the correct atom number.
 
     :param wfn: The wavefunction of the system.
@@ -238,7 +238,9 @@ def _renormalise_wavefunction(wfn: Wavefunction) -> None:
     wfn.fft()
 
 
-def _calculate_atom_num(wfn: Wavefunction) -> tuple[int, int, int, int, int]:
+def _calculate_atom_num(
+    wfn: SpinTwoWavefunction,
+) -> tuple[int, int, int, int, int]:
     """Calculates the atom number of each wavefunction component.
 
     :param wfn: The wavefunction of the system.

--- a/pygpe/spintwo/wavefunction.py
+++ b/pygpe/spintwo/wavefunction.py
@@ -1,9 +1,9 @@
 from pygpe.shared.grid import Grid
-from pygpe.shared.wavefunction import Wavefunction
+from pygpe.shared.wavefunction import _Wavefunction
 import cupy as cp
 
 
-class SpinTwoWavefunction(Wavefunction):
+class SpinTwoWavefunction(_Wavefunction):
     """Represents the spin-2 BEC wavefunction.
     This class contains the wavefunction arrays, in addition to various useful
     functions for manipulating and using the wavefunction.

--- a/pygpe/spintwo/wavefunction.py
+++ b/pygpe/spintwo/wavefunction.py
@@ -1,8 +1,9 @@
 from pygpe.shared.grid import Grid
+from pygpe.shared.wavefunction import Wavefunction
 import cupy as cp
 
 
-class Wavefunction:
+class SpinTwoWavefunction(Wavefunction):
     """Represents the spin-2 BEC wavefunction.
     This class contains the wavefunction arrays, in addition to various useful
     functions for manipulating and using the wavefunction.
@@ -30,7 +31,7 @@ class Wavefunction:
 
     def __init__(self, grid: Grid):
         """Constructs the wavefunction object."""
-        self.grid = grid
+        super().__init__(grid)
 
         self.plus2_component = cp.empty(grid.shape, dtype="complex128")
         self.plus1_component = cp.empty(grid.shape, dtype="complex128")
@@ -75,7 +76,7 @@ class Wavefunction:
 
         self._update_atom_numbers()
 
-    def set_custom_components(
+    def set_wavefunction(
         self,
         plus2_component: cp.ndarray = None,
         plus1_component: cp.ndarray = None,
@@ -102,7 +103,7 @@ class Wavefunction:
         if minus2_component is not None:
             self.minus2_component = minus2_component
 
-    def add_noise_to_components(
+    def add_noise(
         self, components: str | list[str], mean: float, std_dev: float
     ) -> None:
         """Adds noise to the specified wavefunction components
@@ -143,39 +144,29 @@ class Wavefunction:
         """
         match component.lower():
             case "plus2":
-                self.plus2_component += self._generate_complex_normal_dist(
+                self.plus2_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "plus1":
-                self.plus1_component += self._generate_complex_normal_dist(
+                self.plus1_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "zero":
-                self.zero_component += self._generate_complex_normal_dist(
+                self.zero_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "minus1":
-                self.minus1_component += self._generate_complex_normal_dist(
+                self.minus1_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case "minus2":
-                self.minus2_component += self._generate_complex_normal_dist(
+                self.minus2_component += super()._generate_complex_normal_dist(
                     mean, std_dev
                 )
             case _:
                 raise ValueError(
                     f"{component} is not a supported configuration"
                 )
-
-    def _generate_complex_normal_dist(
-        self, mean: float, std_dev: float
-    ) -> cp.ndarray:
-        """Returns a ndarray of complex values containing results from
-        a normal distribution.
-        """
-        return cp.random.normal(
-            mean, std_dev, size=self.grid.shape
-        ) + 1j * cp.random.normal(mean, std_dev, size=self.grid.shape)
 
     def apply_phase(
         self, phase: cp.ndarray, components: str | list[str] = "all"
@@ -262,8 +253,21 @@ class Wavefunction:
         self.minus1_component = cp.fft.ifftn(self.fourier_minus1_component)
         self.minus2_component = cp.fft.ifftn(self.fourier_minus2_component)
 
+    def density(self) -> cp.ndarray:
+        """Returns an array of the total condensate density.
 
-def _uniaxial_initial_state(wfn: Wavefunction, params: dict) -> None:
+        :return: Total condensate density.
+        """
+        return (
+            cp.abs(self.plus2_component) ** 2
+            + cp.abs(self.plus1_component) ** 2
+            + cp.abs(self.zero_component) ** 2
+            + cp.abs(self.minus1_component) ** 2
+            + cp.abs(self.minus2_component) ** 2
+        )
+
+
+def _uniaxial_initial_state(wfn: SpinTwoWavefunction, params: dict) -> None:
     """Sets wavefunction components to uniaxial nematic state."""
     wfn.plus2_component = cp.zeros(wfn.grid.shape, dtype="complex128")
     wfn.plus1_component = cp.zeros(wfn.grid.shape, dtype="complex128")
@@ -274,7 +278,7 @@ def _uniaxial_initial_state(wfn: Wavefunction, params: dict) -> None:
     wfn.minus2_component = cp.zeros(wfn.grid.shape, dtype="complex128")
 
 
-def _biaxial_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _biaxial_initial_state(wfn: SpinTwoWavefunction, params: dict) -> None:
     """Sets wavefunction components to biaxial nematic polar state."""
     wfn.plus2_component = (
         cp.sqrt(params["n0"])
@@ -291,7 +295,9 @@ def _biaxial_initial_state(wfn: Wavefunction, params: dict) -> None:
     )
 
 
-def _ferromagnetic2p_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _ferromagnetic2p_initial_state(
+    wfn: SpinTwoWavefunction, params: dict
+) -> None:
     """Sets wavefunction components to ferromagnetic (F=2) state, with atoms
     in the plus two component.
     """
@@ -304,7 +310,9 @@ def _ferromagnetic2p_initial_state(wfn: Wavefunction, params: dict) -> None:
     wfn.minus2_component = cp.zeros(wfn.grid.shape, dtype="complex128")
 
 
-def _ferromagnetic2m_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _ferromagnetic2m_initial_state(
+    wfn: SpinTwoWavefunction, params: dict
+) -> None:
     """Sets wavefunction components to ferromagnetic (F=2) state, with atoms in
     the minus two component.
     """
@@ -317,7 +325,9 @@ def _ferromagnetic2m_initial_state(wfn: Wavefunction, params: dict) -> None:
     )
 
 
-def _ferromagnetic1p_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _ferromagnetic1p_initial_state(
+    wfn: SpinTwoWavefunction, params: dict
+) -> None:
     """Sets wavefunction components to ferromagnetic (F=1) state, with atoms in
     the plus one component.
     """
@@ -330,7 +340,9 @@ def _ferromagnetic1p_initial_state(wfn: Wavefunction, params: dict) -> None:
     wfn.minus2_component = cp.zeros(wfn.grid.shape, dtype="complex128")
 
 
-def _ferromagnetic1m_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _ferromagnetic1m_initial_state(
+    wfn: SpinTwoWavefunction, params: dict
+) -> None:
     """Sets wavefunction components to ferromagnetic (F=1) state, with atoms in
     the minus one component.
     """
@@ -343,7 +355,7 @@ def _ferromagnetic1m_initial_state(wfn: Wavefunction, params: dict) -> None:
     wfn.minus2_component = cp.zeros(wfn.grid.shape, dtype="complex128")
 
 
-def _cyclic_initial_state(wfn: Wavefunction, params: dict) -> None:
+def _cyclic_initial_state(wfn: SpinTwoWavefunction, params: dict) -> None:
     """Sets wavefunction components to (two-component) cyclic state,
     with atoms in the plus two and minus one components."""
     fz = params["p"] + params["q"] / (params["c2"] * params["n0"])

--- a/tests/scalar/test_scalar_wavefunction.py
+++ b/tests/scalar/test_scalar_wavefunction.py
@@ -2,12 +2,12 @@ import pytest
 import cupy as cp
 from typing import Tuple
 from pygpe.shared.grid import Grid
-from pygpe.scalar.wavefunction import Wavefunction
+from pygpe.scalar.wavefunction import ScalarWavefunction
 
 
 def generate_wavefunction2d(
     points: Tuple[int, int], grid_spacing: Tuple[float, float]
-) -> Wavefunction:
+) -> ScalarWavefunction:
     """Generates and returns a Wavefunction2D object specified
 
     :param points: The number of grid points in the x and y dimension,
@@ -16,7 +16,7 @@ def generate_wavefunction2d(
         respectively.
     :return: The Wavefunction2D object.
     """
-    return Wavefunction(Grid(points, grid_spacing))
+    return ScalarWavefunction(Grid(points, grid_spacing))
 
 
 def test_set_wavefunction():

--- a/tests/spinhalf/test_spinhalf_wavefunction.py
+++ b/tests/spinhalf/test_spinhalf_wavefunction.py
@@ -1,12 +1,12 @@
 import pytest
 import cupy as cp
 from pygpe.shared.grid import Grid
-from pygpe.spinhalf.wavefunction import Wavefunction
+from pygpe.spinhalf.wavefunction import SpinHalfWavefunction
 
 
 def generate_wavefunction2d(
     points: tuple[int, int], grid_spacing: tuple[float, float]
-) -> Wavefunction:
+) -> SpinHalfWavefunction:
     """Generates and returns a Wavefunction2D object specified
 
     :param points: The number of grid points in the x and y dimension,
@@ -15,16 +15,16 @@ def generate_wavefunction2d(
     respectively.
     :return: The Wavefunction2D object.
     """
-    return Wavefunction(Grid(points, grid_spacing))
+    return SpinHalfWavefunction(Grid(points, grid_spacing))
 
 
-def test_set_wavefunction_components():
+def test_set_wavefunction():
     """Tests whether the wavefunction components are set correctly."""
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
 
     plus_component = cp.ones((64, 64), dtype="complex128")
     minus_component = 0.345 * cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     cp.testing.assert_array_equal(wavefunction.plus_component, plus_component)
     cp.testing.assert_array_equal(
@@ -40,7 +40,7 @@ def test_update_atom_numbers():
 
     plus_component = 0.5 * cp.ones((64, 64), dtype="complex128")
     minus_component = 2 * cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     assert wavefunction.atom_num_plus == 256.0 * cp.ones(1)
     assert wavefunction.atom_num_minus == 4096.0 * cp.ones(1)
@@ -54,8 +54,8 @@ def test_adding_noise_plus():
 
     plus_component = cp.zeros((64, 64), dtype="complex128")
     minus_component = cp.zeros((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
-    wavefunction.add_noise_to_components("plus", mean=0, std_dev=1e-2)
+    wavefunction.set_wavefunction(plus_component, minus_component)
+    wavefunction.add_noise("plus", mean=0, std_dev=1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -74,8 +74,8 @@ def test_adding_noise_minus():
 
     plus_component = cp.zeros((64, 64), dtype="complex128")
     minus_component = cp.zeros((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
-    wavefunction.add_noise_to_components("minus", mean=0, std_dev=1e-2)
+    wavefunction.set_wavefunction(plus_component, minus_component)
+    wavefunction.add_noise("minus", mean=0, std_dev=1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -94,8 +94,8 @@ def test_adding_noise_all():
 
     plus_component = cp.zeros((64, 64), dtype="complex128")
     minus_component = cp.zeros((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
-    wavefunction.add_noise_to_components("all", mean=0, std_dev=1e-2)
+    wavefunction.set_wavefunction(plus_component, minus_component)
+    wavefunction.add_noise("all", mean=0, std_dev=1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -113,7 +113,7 @@ def test_phase_all():
 
     plus_component = cp.ones((64, 64), dtype="complex128")
     minus_component = cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     phase = cp.random.uniform(size=(64, 64), dtype=cp.float64)
     wavefunction.apply_phase(phase, components="all")
@@ -123,13 +123,14 @@ def test_phase_all():
 
 
 def test_phase_plus():
-    """Tests that a phase applied to the plus component is applied correctly.
+    """Tests that a phase applied to the plus component is applied
+    correctly.
     """
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
 
     plus_component = cp.ones((64, 64), dtype="complex128")
     minus_component = cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     phase = cp.random.uniform(size=(64, 64), dtype=cp.float64)
     wavefunction.apply_phase(phase, components="plus")
@@ -142,13 +143,14 @@ def test_phase_plus():
 
 
 def test_phase_minus():
-    """Tests that a phase applied to the plus component is applied correctly.
+    """Tests that a phase applied to the plus component is applied
+    correctly.
     """
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
 
     plus_component = cp.ones((64, 64), dtype="complex128")
     minus_component = cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     phase = cp.random.uniform(size=(64, 64), dtype=cp.float64)
     wavefunction.apply_phase(phase, components="minus")
@@ -177,7 +179,7 @@ def test_density():
 
     plus_component = 0.5 * cp.ones((64, 64), dtype="complex128")
     minus_component = 2 * cp.ones((64, 64), dtype="complex128")
-    wavefunction.set_wavefunction_components(plus_component, minus_component)
+    wavefunction.set_wavefunction(plus_component, minus_component)
 
     plus_density = wavefunction.density("plus")
     minus_density = wavefunction.density("minus")

--- a/tests/spinone/test_spinone_evolution.py
+++ b/tests/spinone/test_spinone_evolution.py
@@ -1,6 +1,6 @@
 import cupy as cp
 from pygpe.shared.grid import Grid
-from pygpe.spinone.wavefunction import Wavefunction
+from pygpe.spinone.wavefunction import SpinOneWavefunction
 import pygpe.spinone.evolution as evo
 
 
@@ -8,7 +8,7 @@ def test_spin_vectors_polar():
     """Tests whether the perpendicular and z-component spin vectors are
     correct for a polar wavefunction.
     """
-    wavefunction_polar = Wavefunction(Grid((64, 64), (0.5, 0.5)))
+    wavefunction_polar = SpinOneWavefunction(Grid((64, 64), (0.5, 0.5)))
     wavefunction_polar.set_ground_state("polar", params={"n0": 1.0})
 
     f_perp, f_z = evo._calculate_spins(wavefunction_polar)
@@ -21,7 +21,7 @@ def test_spin_vectors_polar():
 
 def test_density():
     """Tests to see if density is one given a normalised spinor."""
-    wavefunction = Wavefunction(Grid((64, 64), (0.5, 0.5)))
+    wavefunction = SpinOneWavefunction(Grid((64, 64), (0.5, 0.5)))
     wavefunction.set_ground_state("polar", params={"n0": 1.0})
 
     cp.testing.assert_array_equal(
@@ -33,9 +33,9 @@ def test_renormalise():
     """Tests whether wavefunction correctly gets re-normalised after being
     modified.
     """
-    wavefunction_1 = Wavefunction(Grid((64, 64), (0.5, 0.5)))
+    wavefunction_1 = SpinOneWavefunction(Grid((64, 64), (0.5, 0.5)))
     wavefunction_1.set_ground_state("polar", params={"n0": 1.0})
-    wavefunction_1.add_noise_to_components("outer", 0.0, 1e-2)
+    wavefunction_1.add_noise("outer", 0.0, 1e-2)
     wavefunction_1.fft()
 
     wavefunction_2 = wavefunction_1
@@ -57,7 +57,7 @@ def test_renormalise():
 
 def test_atom_number():
     """Tests to see if atom number of wavefunction is calculated correctly."""
-    wavefunction = Wavefunction(Grid((64, 64), (0.5, 0.5)))
+    wavefunction = SpinOneWavefunction(Grid((64, 64), (0.5, 0.5)))
     wavefunction.set_ground_state("polar", params={"n0": 1.0})
 
     assert sum(evo._calculate_atom_num(wavefunction)) == 1024

--- a/tests/spinone/test_spinone_wavefunction.py
+++ b/tests/spinone/test_spinone_wavefunction.py
@@ -2,12 +2,12 @@ import pytest
 import cupy as cp
 from typing import Tuple
 from pygpe.shared.grid import Grid
-from pygpe.spinone.wavefunction import Wavefunction
+from pygpe.spinone.wavefunction import SpinOneWavefunction
 
 
 def generate_wavefunction2d(
     points: Tuple[int, int], grid_spacing: Tuple[float, float]
-) -> Wavefunction:
+) -> SpinOneWavefunction:
     """Generates and returns a Wavefunction2D object specified
 
     :param points: The number of grid points in the x and y dimension,
@@ -16,7 +16,7 @@ def generate_wavefunction2d(
         respectively.
     :return: The Wavefunction2D object.
     """
-    return Wavefunction(Grid(points, grid_spacing))
+    return SpinOneWavefunction(Grid(points, grid_spacing))
 
 
 def test_polar_initial_state():
@@ -90,7 +90,7 @@ def test_custom_wavefunction_components():
     zero_component = 1e4 * cp.ones((64, 64))
     minus_component = cp.zeros((64, 64))
 
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         plus_component, zero_component, minus_component
     )
 
@@ -114,10 +114,10 @@ def test_adding_noise_outer():
     """
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
     zeros = cp.zeros(wavefunction.grid.shape, dtype="complex128")
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.zeros_like(zeros), cp.zeros_like(zeros), cp.zeros_like(zeros)
     )
-    wavefunction.add_noise_to_components("outer", 0, 1e-2)
+    wavefunction.add_noise("outer", 0, 1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -135,10 +135,10 @@ def test_adding_noise_all():
     """
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
     zeros = cp.zeros(wavefunction.grid.shape, dtype="complex128")
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.zeros_like(zeros), cp.zeros_like(zeros), cp.zeros_like(zeros)
     )
-    wavefunction.add_noise_to_components("all", 0, 1e-2)
+    wavefunction.add_noise("all", 0, 1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -160,10 +160,10 @@ def test_adding_noise_zero():
     """
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
     zeros = cp.zeros(wavefunction.grid.shape, dtype="complex128")
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.zeros_like(zeros), cp.zeros_like(zeros), cp.zeros_like(zeros)
     )
-    wavefunction.add_noise_to_components("zero", 0, 1e-2)
+    wavefunction.add_noise("zero", 0, 1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -176,10 +176,10 @@ def test_adding_noise_list():
     correctly makes those components non-zero."""
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
     zeros = cp.zeros(wavefunction.grid.shape, dtype="complex128")
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.zeros_like(zeros), cp.zeros_like(zeros), cp.zeros_like(zeros)
     )
-    wavefunction.add_noise_to_components(["plus", "zero"], 0, 1e-2)
+    wavefunction.add_noise(["plus", "zero"], 0, 1e-2)
 
     with pytest.raises(AssertionError):
         cp.testing.assert_array_equal(
@@ -194,7 +194,7 @@ def test_adding_noise_list():
 def test_phase_all():
     """Tests that a phase applied to all components is applied correctly."""
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),
@@ -211,7 +211,7 @@ def test_phase_all():
 def test_phase_multiple_components():
     """Tests that a phase is applied correctly to multiple components."""
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),
@@ -227,7 +227,7 @@ def test_phase_multiple_components():
 def test_phase_single():
     """Tests that a phase is applied correctly to a single component."""
     wavefunction = generate_wavefunction2d((64, 64), (0.5, 0.5))
-    wavefunction.set_custom_components(
+    wavefunction.set_wavefunction(
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),
         cp.ones((64, 64), dtype="complex128"),


### PR DESCRIPTION
This PR brings a re-design of the existing `Wavefunction` classes (closes #2). Now, there is a (private) abstract `Wavefunction` class which each system inherits from. 
Each system has a new `Wavefunction` class: `ScalarWavefunction`, `SpinHalfWavefunction`, `SpinOneWavefunction`, and `SpinTwoWavefunction` to avoid confusing between the different systems.

Additionally, certain methods in the multi-component systems have been renamed as to provide a consistent interface between all systems. For example, `add_noise_to_components` is now `add_noise` for all system types.

This update brings much better readability to the codebase, and should allow for easier refactoring of other classes down the line.