### PR TITLE
Fix data manager paths

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@ import sys
 project = "PyGPE"
 copyright = "2023, Matt Wheeler"
 author = "Matt Wheeler"
-release = "1.2.1"
+release = "1.2.2"
 
 sys.path.insert(0, os.path.abspath("../../"))
 

--- a/examples/scalar/2d_SQV_imprinting.py
+++ b/examples/scalar/2d_SQV_imprinting.py
@@ -22,7 +22,7 @@ psi.apply_phase(cp.asarray(phase))  # Apply phase to wavefunction
 params = {"g": 1, "trap": 0, "nt": 1000, "dt": -1j * 1e-2, "t": 0}
 
 # Create DataManager
-data = gpe.DataManager("scalar_data.hdf5", "data/", psi, params)
+data = gpe.DataManager("scalar_data.hdf5", "data", psi, params)
 
 psi.fft()  # FFT to ensure k-space wavefunction is up-to-date
 start_time = time.time()  # Start timer

--- a/examples/spinone/2d_SQV_imprinting.py
+++ b/examples/spinone/2d_SQV_imprinting.py
@@ -34,7 +34,7 @@ phase = cp.asarray(
 psi.apply_phase(phase)  # Apply phase to all spinor components
 
 # Generate DataManager to store data for simulation
-data = gpe.DataManager("data.hdf5", "data/", psi, params)
+data = gpe.DataManager("spin_one_data.hdf5", "data", psi, params)
 
 psi.fft()  # Ensures k-space wavefunction components are up-to-date before evolution
 start_time = time.time()

--- a/pygpe/scalar/data_manager.py
+++ b/pygpe/scalar/data_manager.py
@@ -31,7 +31,7 @@ class DataManager(_DataManager):
 
     def _save_initial_wfn(self, wfn: ScalarWavefunction) -> None:
         """Saves initial wavefunction to dataset."""
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path_and_file, "r+") as file:
             if wfn.grid.ndim == 1:
                 file.create_dataset(
                     dmp.SCALAR_WAVEFUNCTION,
@@ -54,7 +54,7 @@ class DataManager(_DataManager):
         :type wfn: :class:`Wavefunction`
         """
         wfn.ifft()  # Update real-space wavefunction before saving
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as data:
+        with h5py.File(self.data_path_and_file, "r+") as data:
             if wfn.grid.ndim == 1:
                 new_psi = data[dmp.SCALAR_WAVEFUNCTION]
                 new_psi.resize((wfn.grid.num_points_x, self._time_index + 1))

--- a/pygpe/shared/data_manager.py
+++ b/pygpe/shared/data_manager.py
@@ -3,6 +3,7 @@ import pygpe.shared.data_manager_paths as dmp
 from abc import ABC, abstractmethod
 from pygpe.shared.grid import Grid
 from pygpe.shared.wavefunction import _Wavefunction
+from pathlib import Path
 
 
 class _DataManager(ABC):
@@ -27,17 +28,18 @@ class _DataManager(ABC):
         :type params: dict
         """
         self.filename = filename
-        self.data_path = data_path
+        self.data_path = Path(f"./{data_path}")
+        self.data_path_and_file = self.data_path / self.filename
         self._time_index = 0
 
         # Create file and save initial parameters
-        h5py.File(f"{self.data_path}/{self.filename}", "w")
+        h5py.File(self.data_path_and_file, "w")
         self._save_grid_params(wfn.grid)
         self._save_params(params)
 
     def _save_grid_params(self, grid: Grid) -> None:
         """Saves grid parameters to dataset."""
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path_and_file, "r+") as file:
             if grid.ndim == 1:
                 file.create_dataset(dmp.GRID_NX, data=grid.num_points_x)
                 file.create_dataset(dmp.GRID_DX, data=grid.grid_spacing_x)
@@ -56,7 +58,7 @@ class _DataManager(ABC):
 
     def _save_params(self, parameters: dict) -> None:
         """Saves condensate parameters to dataset."""
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path / self.filename, "r+") as file:
             for key in parameters:
                 file.create_dataset(
                     f"{dmp.PARAMETERS}/{key}", data=parameters[key]

--- a/pygpe/spinhalf/data_manager.py
+++ b/pygpe/spinhalf/data_manager.py
@@ -33,7 +33,7 @@ class DataManager(_DataManager):
         """Creates new datasets in file for the wavefunction and saves
         initial values.
         """
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path_and_file, "r+") as file:
             if wfn.grid.ndim == 1:
                 file.create_dataset(
                     dmp.SPINHALF_WAVEFUNCTION_PLUS,
@@ -68,7 +68,7 @@ class DataManager(_DataManager):
         :type wfn: :class:`Wavefunction`
         """
         wfn.ifft()  # Update real-space wavefunction before saving
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as data:
+        with h5py.File(self.data_path_and_file, "r+") as data:
             if wfn.grid.ndim == 1:
                 new_psi_plus = data[dmp.SPINHALF_WAVEFUNCTION_PLUS]
                 new_psi_plus.resize(

--- a/pygpe/spinone/data_manager.py
+++ b/pygpe/spinone/data_manager.py
@@ -33,7 +33,7 @@ class DataManager(_DataManager):
         """Creates new datasets in file for the wavefunction and saves
         initial values.
         """
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path_and_file, "r+") as file:
             if wfn.grid.ndim == 1:
                 file.create_dataset(
                     dmp.SPIN1_WAVEFUNCTION_PLUS,
@@ -80,7 +80,7 @@ class DataManager(_DataManager):
         :type wfn: :class:`Wavefunction`
         """
         wfn.ifft()  # Update real-space wavefunction before saving
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as data:
+        with h5py.File(self.data_path_and_file, "r+") as data:
             if wfn.grid.ndim == 1:
                 new_psi_plus = data[dmp.SPIN1_WAVEFUNCTION_PLUS]
                 new_psi_plus.resize(

--- a/pygpe/spintwo/data_manager.py
+++ b/pygpe/spintwo/data_manager.py
@@ -31,7 +31,7 @@ class DataManager(_DataManager):
 
     def _save_initial_wfn(self, wfn: SpinTwoWavefunction) -> None:
         """Creates new datasets in file for the wavefunction."""
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as file:
+        with h5py.File(self.data_path_and_file, "r+") as file:
             if wfn.grid.ndim == 1:
                 file.create_dataset(
                     dmp.SPIN2_WAVEFUNCTION_PLUS_TWO,
@@ -102,7 +102,7 @@ class DataManager(_DataManager):
         :type wfn: :class:`Wavefunction`
         """
         wfn.ifft()  # Update real-space wavefunction before saving
-        with h5py.File(f"{self.data_path}/{self.filename}", "r+") as data:
+        with h5py.File(self.data_path_and_file, "r+") as data:
             if wfn.grid.ndim == 1:
                 new_psi_plus2 = data[dmp.SPIN2_WAVEFUNCTION_PLUS_TWO]
                 new_psi_plus2.resize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygpe"
-version = "1.2.1"
+version = "1.2.2"
 description = "A fast Gross-Pitaevskii equation solver for scalar, spin-1 and spin-2 BEC systems."
 readme = "docs/pypi.md"
 authors = [{ name = "Matt Wheeler", email = "mattwheeler15@hotmail.co.uk" }]
@@ -28,7 +28,7 @@ Homepage = "https://github.com/wheelerMT/pygpe"
 packages = ["pygpe", "pygpe.shared", "pygpe.scalar", "pygpe.spinhalf", "pygpe.spinone", "pygpe.spintwo"]
 
 [tool.bumpver]
-current_version = "1.2.1"
+current_version = "1.2.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
Fixes `Unable to create file errors` that can occur when first constructing the DataManager classes. The solution is to instead use Pathlib to generate proper file paths.