### PR TITLE
Fix: remove redundant imports

### DIFF
--- a/pygpe/scalar/data_manager.py
+++ b/pygpe/scalar/data_manager.py
@@ -1,9 +1,5 @@
 import h5py
 
-try:
-    import cupy as cp
-except ImportError:
-    import numpy as cp
 from pygpe.shared import data_manager_paths as dmp
 from pygpe.shared.utils import handle_array
 from pygpe.shared.data_manager import _DataManager

--- a/pygpe/spinhalf/data_manager.py
+++ b/pygpe/spinhalf/data_manager.py
@@ -1,9 +1,5 @@
 import h5py
 
-try:
-    import cupy as cp
-except ImportError:
-    import numpy as cp
 from pygpe.shared import data_manager_paths as dmp
 from pygpe.shared.utils import handle_array
 from pygpe.shared.data_manager import _DataManager

--- a/pygpe/spinone/data_manager.py
+++ b/pygpe/spinone/data_manager.py
@@ -1,9 +1,5 @@
 import h5py
 
-try:
-    import cupy as cp
-except ImportError:
-    import numpy as cp
 from pygpe.shared.data_manager import _DataManager
 from pygpe.shared.utils import handle_array
 from pygpe.shared import data_manager_paths as dmp

--- a/pygpe/spintwo/data_manager.py
+++ b/pygpe/spintwo/data_manager.py
@@ -1,9 +1,5 @@
 import h5py
 
-try:
-    import cupy as cp
-except ImportError:
-    import numpy as cp
 from pygpe.shared.data_manager import _DataManager
 from pygpe.shared.utils import handle_array
 from pygpe.shared import data_manager_paths as dmp


### PR DESCRIPTION
Remove redundant imports in data manager files.

These imports are no longer required since the wave function arrays are handled directly with `handle_array`.