### PR TITLE
Add disspation to scalar evolution, add example dipole decay script

### DIFF
--- a/examples/scalar/2d_decay.py
+++ b/examples/scalar/2d_decay.py
@@ -1,0 +1,74 @@
+import time
+import os
+
+try:
+    import cupy as cp
+except ImportError:
+    import numpy as cp
+import matplotlib.pyplot as plt
+import imageio
+
+from pygpe.scalar import Grid, ScalarWavefunction, DataManager, step_wavefunction
+from pygpe.shared.vortices import add_dipole_pair
+
+# Generate grid
+points = (128, 128)
+grid_spacings = (0.5, 0.5)
+grid = Grid(points, grid_spacings)
+
+# Set up initial wavefunction with uniform density
+psi = ScalarWavefunction(grid)
+psi.set_wavefunction(cp.ones(grid.shape, dtype="complex128"))
+psi.add_noise(mean=0.0, std_dev=1e-2)  # Add noise to wavefunction
+
+# Generate phase with a dipole pair seperated 2.0 unuts apart
+phase = add_dipole_pair(grid, 2.0)
+psi.apply_phase(cp.asarray(phase))  # Apply phase to wavefunction
+
+# Define condensate parameters (small disspation added)
+params = {"g": 1, "trap": 0, "nt": 10000, "dt": 1e-2, "t": 0, "gamma": 0.01}
+
+# Create DataManager
+data = DataManager("scalar_data.hdf5", "data", psi, params)
+
+psi.fft()  # FFT to ensure k-space wavefunction is up-to-date
+start_time = time.time()  # Start timer
+
+# Prepare directory for frames
+frames_dir = "frames"
+os.makedirs(frames_dir, exist_ok=True)
+
+frame_files = []
+for i in range(params["nt"]):
+    # Evolve wavefunction
+    step_wavefunction(psi, params)
+
+    if i % 100 == 0:  # Save wavefunction data and create a frame
+        frame_path = f"{frames_dir}/frame_{i:04d}.png"
+        frame_files.append(frame_path)
+        plt.figure(figsize=(6, 6))
+        plt.imshow(psi.density(), vmin=0, vmax=1)
+        plt.colorbar()
+        plt.title(f't = {params["t"]:.2f}')
+        plt.savefig(frame_path)
+        plt.close()
+
+    params["t"] += params["dt"]  # Increment time count
+
+print(f'Evolution of {params["nt"]} steps took {time.time() - start_time} seconds!')
+
+# Create movie using imageio
+with imageio.get_writer('wavefunction_evolution.mp4', fps=10) as writer:
+    for filename in frame_files:
+        image = imageio.imread(filename)
+        writer.append_data(image)
+
+# Clean up frames
+import shutil
+shutil.rmtree(frames_dir)
+
+# Show the last frame
+plt.imshow(cp.asnumpy(psi.density()), vmin=0, vmax=1)
+plt.colorbar()
+plt.show()
+

--- a/pygpe/scalar/evolution.py
+++ b/pygpe/scalar/evolution.py
@@ -18,27 +18,27 @@ def step_wavefunction(wfn: ScalarWavefunction, params: dict) -> None:
     _potential_step(wfn, params)
     wfn.fft()
     _kinetic_step(wfn, params)
-    if isinstance(params["dt"], complex):
+    if isinstance(params["dt"], complex) or (params.get("gamma", 0) != 0):
         _renormalise_wavefunction(wfn)
 
-
 def _kinetic_step(wfn: ScalarWavefunction, pm: dict) -> None:
-    """Computes the kinetic energy subsystem for half a time step.
+    """Computes the kinetic energy subsystem for half a time step, including dissipation.
 
     :param wfn: The wavefunction of the system.
     :param pm: The parameters' dictionary.
     """
-    wfn.fourier_component *= cp.exp(-0.25 * 1j * pm["dt"] * wfn.grid.wave_number)
-
+    gamma = pm.get('gamma', 0)  # Dissipation coefficient, default to 0 if unspecified
+    wfn.fourier_component *= cp.exp(-0.25 * (1 - 1j * gamma) * 1j * pm["dt"] * wfn.grid.wave_number)
 
 def _potential_step(wfn: ScalarWavefunction, pm: dict) -> None:
-    """Computes the potential subsystem for a full time step.
+    """Computes the potential subsystem for a full time step, including dissipation.
 
     :param wfn: The wavefunction of the system.
     :param pm: The parameters' dictionary.
     """
+    gamma = pm.get('gamma', 0)  # Dissipation coefficient, default to 0 if unspecified
     wfn.component *= cp.exp(
-        -1j * pm["dt"] * (pm["trap"] + pm["g"] * cp.abs(wfn.component) ** 2)
+        -1j * pm["dt"] * (1 - 1j * gamma) * (pm["trap"] + pm["g"] * cp.abs(wfn.component) ** 2)
     )
 
 


### PR DESCRIPTION


Added phenomenological dissipation (1-i\gamma)*(RHS) to scalar GPE, common to some other GPE solvers [1]. can be added to params list as "gamma" and if unspecified defaults to zero. 

Also added a method to generate a vortex dipole some defined distance apart in the centre of the computational box which is used by an example script to demonstrate the effects of dissipation on a vortex dipole pair. :)

[1] Choi, S., S. A. Morgan, and K. Burnett. "Phenomenological damping in trapped atomic Bose-Einstein condensates." Physical Review A 57.5 (1998): 4057.