### PR TITLE
`cp.asarray` calls fix

### DIFF
--- a/examples/scalar/2d_SQV_imprinting.py
+++ b/examples/scalar/2d_SQV_imprinting.py
@@ -22,7 +22,7 @@ psi.add_noise(mean=0.0, std_dev=1e-2)  # Add noise to wavefunction
 
 # Generate phase that contains 100 phase windings spaced at least 1 spatial unit apart
 phase = vortex_phase_profile(grid, 100, 1.0)
-psi.apply_phase(cp.asarray(phase))  # Apply phase to wavefunction
+psi.apply_phase(phase)  # Apply phase to wavefunction
 
 # Define condensate parameters
 params = {"g": 1, "trap": 0, "nt": 1000, "dt": -1j * 1e-2, "t": 0}

--- a/examples/scalar/2d_decay.py
+++ b/examples/scalar/2d_decay.py
@@ -23,7 +23,7 @@ psi.add_noise(mean=0.0, std_dev=1e-2)  # Add noise to wavefunction
 
 # Generate phase with a dipole pair seperated 2.0 unuts apart
 phase = add_dipole_pair(grid, 2.0)
-psi.apply_phase(cp.asarray(phase))  # Apply phase to wavefunction
+psi.apply_phase(phase)  # Apply phase to wavefunction
 
 # Define condensate parameters (small disspation added)
 params = {"g": 1, "trap": 0, "nt": 10000, "dt": 1e-2, "t": 0, "gamma": 0.01}
@@ -58,17 +58,17 @@ for i in range(params["nt"]):
 print(f'Evolution of {params["nt"]} steps took {time.time() - start_time} seconds!')
 
 # Create movie using imageio
-with imageio.get_writer('wavefunction_evolution.mp4', fps=10) as writer:
+with imageio.get_writer("wavefunction_evolution.mp4", fps=10) as writer:
     for filename in frame_files:
         image = imageio.imread(filename)
         writer.append_data(image)
 
 # Clean up frames
 import shutil
+
 shutil.rmtree(frames_dir)
 
 # Show the last frame
 plt.imshow(cp.asnumpy(psi.density()), vmin=0, vmax=1)
 plt.colorbar()
 plt.show()
-

--- a/examples/spinone/2d_SQV_imprinting.py
+++ b/examples/spinone/2d_SQV_imprinting.py
@@ -34,8 +34,8 @@ psi = gpe.SpinOneWavefunction(grid)
 psi.set_ground_state("polar", params)
 psi.add_noise("outer", 0.0, 1e-2)
 
-phase = cp.asarray(
-    vort.vortex_phase_profile(grid, 100, 1)
+phase = vort.vortex_phase_profile(
+    grid, 100, 1
 )  # Get 100 phase windings with a min distance of 1
 psi.apply_phase(phase)  # Apply phase to all spinor components
 

--- a/pygpe/shared/grid.py
+++ b/pygpe/shared/grid.py
@@ -105,8 +105,7 @@ class Grid:
             * self.fourier_spacing_x
         )
 
-        # Defined on device for use in evolution
-        self.wave_number = cp.asarray(self.fourier_x_mesh**2)
+        self.wave_number = self.fourier_x_mesh**2
 
     def _generate_2d_grids(
         self, points: tuple[int, ...], grid_spacings: tuple[float, ...]
@@ -148,10 +147,7 @@ class Grid:
         self.fourier_x_mesh = cp.fft.fftshift(self.fourier_x_mesh)
         self.fourier_y_mesh = cp.fft.fftshift(self.fourier_y_mesh)
 
-        # Defined on device for use in evolution
-        self.wave_number = cp.asarray(
-            self.fourier_x_mesh**2 + self.fourier_y_mesh**2
-        )
+        self.wave_number = self.fourier_x_mesh**2 + self.fourier_y_mesh**2
 
     def _generate_3d_grids(
         self, points: tuple[int, ...], grid_spacings: tuple[float, ...]
@@ -212,9 +208,6 @@ class Grid:
         self.fourier_y_mesh = cp.fft.fftshift(self.fourier_y_mesh)
         self.fourier_z_mesh = cp.fft.fftshift(self.fourier_z_mesh)
 
-        # Defined on device for use in evolution
-        self.wave_number = cp.asarray(
-            self.fourier_x_mesh**2
-            + self.fourier_y_mesh**2
-            + self.fourier_z_mesh**2
+        self.wave_number = (
+            self.fourier_x_mesh**2 + self.fourier_y_mesh**2 + self.fourier_z_mesh**2
         )

--- a/tests/scalar/test_data_manager.py
+++ b/tests/scalar/test_data_manager.py
@@ -74,7 +74,7 @@ def test_correct_wavefunction():
     DataManager(FILENAME, FILE_PATH, wavefunction, params)
 
     with h5py.File(f"{FILE_PATH}/{FILENAME}", "r") as file:
-        saved_wavefunction = np.asarray(file[f"{dmp.SCALAR_WAVEFUNCTION}"][:, :, 0])
+        saved_wavefunction = file[f"{dmp.SCALAR_WAVEFUNCTION}"][:, :, 0]
         np.testing.assert_array_almost_equal(wavefunction.component, saved_wavefunction)
 
     Path.unlink(Path(f"{FILE_PATH}/{FILENAME}"))

--- a/tests/spinhalf/test_spinhalf_data_manager.py
+++ b/tests/spinhalf/test_spinhalf_data_manager.py
@@ -82,15 +82,11 @@ def test_correct_wavefunction():
     DataManager(FILENAME, FILE_PATH, wavefunction, params)
 
     with h5py.File(f"{FILE_PATH}/{FILENAME}", "r") as file:
-        saved_wavefunction_plus = np.asarray(
-            file[f"{dmp.SPINHALF_WAVEFUNCTION_PLUS}"][:, :, 0]
-        )
+        saved_wavefunction_plus = file[f"{dmp.SPINHALF_WAVEFUNCTION_PLUS}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.plus_component, saved_wavefunction_plus
         )
-        saved_wavefunction_minus = np.asarray(
-            file[f"{dmp.SPINHALF_WAVEFUNCTION_MINUS}"][:, :, 0]
-        )
+        saved_wavefunction_minus = file[f"{dmp.SPINHALF_WAVEFUNCTION_MINUS}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.minus_component, saved_wavefunction_minus
         )

--- a/tests/spinone/test_spinone_data_manager.py
+++ b/tests/spinone/test_spinone_data_manager.py
@@ -83,21 +83,15 @@ def test_correct_wavefunction():
     DataManager(FILENAME, FILE_PATH, wavefunction, params)
 
     with h5py.File(f"{FILE_PATH}/{FILENAME}", "r") as file:
-        saved_wavefunction_plus = np.asarray(
-            file[f"{dmp.SPIN1_WAVEFUNCTION_PLUS}"][:, :, 0]
-        )
+        saved_wavefunction_plus = file[f"{dmp.SPIN1_WAVEFUNCTION_PLUS}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.plus_component, saved_wavefunction_plus
         )
-        saved_wavefunction_zero = np.asarray(
-            file[f"{dmp.SPIN1_WAVEFUNCTION_ZERO}"][:, :, 0]
-        )
+        saved_wavefunction_zero = file[f"{dmp.SPIN1_WAVEFUNCTION_ZERO}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.zero_component, saved_wavefunction_zero
         )
-        saved_wavefunction_minus = np.asarray(
-            file[f"{dmp.SPIN1_WAVEFUNCTION_MINUS}"][:, :, 0]
-        )
+        saved_wavefunction_minus = file[f"{dmp.SPIN1_WAVEFUNCTION_MINUS}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.minus_component, saved_wavefunction_minus
         )

--- a/tests/spintwo/test_spintwo_data_manager.py
+++ b/tests/spintwo/test_spintwo_data_manager.py
@@ -84,33 +84,23 @@ def test_correct_wavefunction():
     DataManager(FILENAME, FILE_PATH, wavefunction, params)
 
     with h5py.File(f"{FILE_PATH}/{FILENAME}", "r") as file:
-        saved_wavefunction_plus2 = np.asarray(
-            file[f"{dmp.SPIN2_WAVEFUNCTION_PLUS_TWO}"][:, :, 0]
-        )
+        saved_wavefunction_plus2 = file[f"{dmp.SPIN2_WAVEFUNCTION_PLUS_TWO}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.plus2_component, saved_wavefunction_plus2
         )
-        saved_wavefunction_plus1 = np.asarray(
-            file[f"{dmp.SPIN2_WAVEFUNCTION_PLUS_ONE}"][:, :, 0]
-        )
+        saved_wavefunction_plus1 = file[f"{dmp.SPIN2_WAVEFUNCTION_PLUS_ONE}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.plus1_component, saved_wavefunction_plus1
         )
-        saved_wavefunction_zero = np.asarray(
-            file[f"{dmp.SPIN2_WAVEFUNCTION_ZERO}"][:, :, 0]
-        )
+        saved_wavefunction_zero = file[f"{dmp.SPIN2_WAVEFUNCTION_ZERO}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.zero_component, saved_wavefunction_zero
         )
-        saved_wavefunction_minus1 = np.asarray(
-            file[f"{dmp.SPIN2_WAVEFUNCTION_MINUS_ONE}"][:, :, 0]
-        )
+        saved_wavefunction_minus1 = file[f"{dmp.SPIN2_WAVEFUNCTION_MINUS_ONE}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.minus1_component, saved_wavefunction_minus1
         )
-        saved_wavefunction_minus2 = np.asarray(
-            file[f"{dmp.SPIN2_WAVEFUNCTION_MINUS_TWO}"][:, :, 0]
-        )
+        saved_wavefunction_minus2 = file[f"{dmp.SPIN2_WAVEFUNCTION_MINUS_TWO}"][:, :, 0]
         np.testing.assert_array_almost_equal(
             wavefunction.minus2_component, saved_wavefunction_minus2
         )


### PR DESCRIPTION
`cp.asarray` calls wrapping the phase profile are now no longer needed throughout the codebase. The phase is now generated on the respective device automatically, e.g., on the GPU if using CuPy and on the CPU if using NumPy.

In addition, `np.asarray` calls wrapped calls to the data file in all the data_manager tests. This is redundant as we implicitly convert to NumPy arrays using the [...] syntax.